### PR TITLE
WIP: Add caching vector to OpenSim::Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ v4.2
 - Fix a segfault that occurs when using OpenSim's Python Package with Anaconda's Python on a Mac.
 - Expose PropertyHelper class to python bindings to allow editing of objects using the properties interface (useful for editing objects defined in plugins) in python (consistent with Java/Matlab).
 - Whitespace is trimmed when reading table metadata for STO, MOT, and CSV files.
+- Minor performance improvements (5-10 %) for controller-heavy models (PR #2806)
+- `Controller::isEnabled` will now only return whether the particular controller is enabled
+  - Previously, it would return `false` if its parent `Model`'s `Model::getAllControllersEnabled` returned `false`
+  - The previous behavior would mean that `Controller::setEnabled(true); return Controller::isEnabled();` could return `false`
 
 
 v4.1

--- a/OpenSim/Simulation/Control/Controller.cpp
+++ b/OpenSim/Simulation/Control/Controller.cpp
@@ -105,11 +105,7 @@ void Controller::updateFromXMLNode(SimTK::Xml::Element& node,
  */
 bool Controller::isEnabled() const
 {
-    if( getModel().getAllControllersEnabled() ) {
-       return( get_enabled() );
-    } else {
-       return( false );
-    }
+    return get_enabled();
 }
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1925,12 +1925,11 @@ const Vector& Model::getControls(const SimTK::State &s) const
 /** Compute the controls the model */
 void Model::computeControls(const SimTK::State& s, SimTK::Vector &controls) const
 {
-    if (not this->getAllControllersEnabled()) {
+    if (!this->getAllControllersEnabled()) {
         return;
     }
 
-    for (const auto& controllerRefWrapper : this->_enabledControllers) {
-        const Controller& controller = controllerRefWrapper.get();
+    for (const Controller& controller : this->_enabledControllers) {
         controller.computeControls(s, controls);
     }
 }

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -1141,6 +1141,18 @@ private:
     // initializeState() or initSystem() is called.
     SimTK::State _workingState;
 
+    // A cached list of `Controller`s that were enabled in the model
+    // when `Model::extendConnectToModel(Model&)` was called.
+    //
+    // This only exists to improve performance. At runtime,
+    // `Model::computeControls(...)` may be called many times. Without
+    // this cache, the implementation must repeatably call
+    // `getComponentList<Controller>`, which is expensive because it
+    // uses runtime `dynamic_cast`s to iterate over, and downcast, a
+    // sequence of `Component`s. For controller-heavy models,
+    // pre-caching controllers into this vector can improve perf by
+    // >5%.
+    std::vector<std::reference_wrapper<const Controller>> _enabledControllers{};
 
     //--------------------------------------------------------------------------
     //                              RUN TIME 


### PR DESCRIPTION
This PR is for looking into caching the `Controller`s owned by a `Model` so that `computeControls` doesn't have to do an expensive `getComponentList` lookup. 

Basic profiling reveals that `getComponentList<T>` is somewhat expensive because it calls `dynamic_cast` on each element in the underlying component list. One way to get around this is to cache all `Controller`s pre-computation.