### PR TITLE
WIP: Speedup StateVector printing

### DIFF
--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -23,8 +23,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/* Note: This code was originally developed by Realistic Dynamics Inc. 
- * Author: Frank C. Anderson 
+/* Note: This code was originally developed by Realistic Dynamics Inc.
+ * Author: Frank C. Anderson
  */
 
 
@@ -37,9 +37,7 @@
 const int IO_STRLEN = 2048;
 
 
-namespace OpenSim { 
-//=============================================================================
-//=============================================================================
+namespace OpenSim {
 /**
  * A class for performing input and output with OpenSim API.
  *
@@ -47,51 +45,20 @@ namespace OpenSim {
  * @author Frank C. Anderson
  */
 class OSIMCOMMON_API IO {
-
-//=============================================================================
-// DATA
-//=============================================================================
-private:
-    // NUMBER OUTPUT
-    /** Specifies whether number output is in scientific or float format. */
-    static bool _Scientific;
-    /** Specifies whether number output is in %g format or not. */
-    static bool _GFormatForDoubleOutput;
-    /** Specifies number of digits of padding in number output. */ 
-    static int _Pad;
-    /** Specifies the precision of number output. */
-    static int _Precision;
-    /** The output format string. */
-    static char _DoubleFormat[256];
-    /** Whether offline documents should also be printed when Object::print is called. */
-    static bool _PrintOfflineDocuments;
-
-
-//=============================================================================
-// METHODS
-//=============================================================================
 public:
     // FILE NAMES
     static char* ConstructDateAndTimeStamp();
     static std::string FixSlashesInFilePath(const std::string &path);
-    // NUMBER OUTPUT FORMAT
-    static void SetScientific(bool aTrueFalse);
-    static bool GetScientific();
-    static void SetGFormatForDoubleOutput(bool aTrueFalse);
-    static bool GetGFormatForDoubleOutput();
-    static void SetDigitsPad(int aPad);
-    static int GetDigitsPad();
-    static void SetPrecision(int aPlaces);
-    static int GetPrecision();
-    static const char*
-        GetDoubleOutputFormat();
-private:
-    static void ConstructDoubleOutputFormat();
 
-public:
+    // NUMBER OUTPUT FORMAT
+    static void SetDigitsPad(int aPad);
+    static void SetPrecision(int aPlaces);
+    static std::string FormatDouble(double d);
+
     // Object printing
     static void SetPrintOfflineDocuments(bool aTrueFalse);
     static bool GetPrintOfflineDocuments();
+
     // READ
 #ifndef SWIG
     static std::string ReadToTokenLine(std::istream &aIS,const std::string &aToken);
@@ -103,6 +70,7 @@ public:
     static std::ifstream* OpenInputFile(const std::string &aFileName,std::ios_base::openmode mode=std::ios_base::in);
     static std::ofstream* OpenOutputFile(const std::string &aFileName,std::ios_base::openmode mode=std::ios_base::out);
 #endif
+
     // Directory management
     static int makeDir(const std::string &aDirName);
     static int chDir(const std::string &aDirName);
@@ -121,11 +89,7 @@ public:
     static std::string Lowercase(const std::string &aStr);
     static std::string Uppercase(const std::string &aStr);
     static void eraseEmptyElements(std::vector<std::string>& list);
-//=============================================================================
-};  // END CLASS IO
-
-}; //namespace
-//=============================================================================
-//=============================================================================
+};
+}
 
 #endif // __IO_h__

--- a/OpenSim/Common/StateVector.cpp
+++ b/OpenSim/Common/StateVector.cpp
@@ -21,8 +21,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/* Note: This code was originally developed by Realistic Dynamics Inc. 
- * Author: Frank C. Anderson 
+/* Note: This code was originally developed by Realistic Dynamics Inc.
+ * Author: Frank C. Anderson
  */
 
 
@@ -166,7 +166,7 @@ getTime() const
 //_____________________________________________________________________________
 /**
  * Set the state values of this vector.
- * 
+ *
  * @param aT Time-stamp of the state vector.
  * @param data Array of values to set the state to.
  */
@@ -306,7 +306,7 @@ add(const SimTK::Vector_<double>& values) {
 /**
  * Add a value to a state.
  *
- * Only one state is altered.  This function was implemented so that 
+ * Only one state is altered.  This function was implemented so that
  * a value could be added to an entire column of a Storage.
  *
  * @param aN Index of state to be altered.
@@ -488,7 +488,7 @@ void StateVector::divide(const SimTK::Vector_<double>& values) {
     int i, n = values.size();
     if(n > _data.getSize())
         n = _data.getSize();
-    for(i = 0; i < n; ++i) {  
+    for(i = 0; i < n; ++i) {
         if(values[i] == 0.0)
             _data[i] = SimTK::NaN;
         else
@@ -515,7 +515,7 @@ divide(StateVector *aStateVector)
 
     // DIVIDE
     int i;
-    for(i=0;i<n;i++) {  
+    for(i=0;i<n;i++) {
         if(data[i]==0.0)    _data[i] = SimTK::NaN;
         else    _data[i] /= data[i];
     }
@@ -535,41 +535,29 @@ divide(StateVector *aStateVector)
 int StateVector::
 print(FILE *fp) const
 {
-    // CHECK FILE POINTER
-    if(fp==NULL) {
+    if (fp == nullptr) {
         log_error("StateVector.print(FILE*): null file pointer.");
-        return(-1);
+        return -1;
     }
 
-    // TIME
-    char format[IO_STRLEN];
-    sprintf(format,"%s",IO::GetDoubleOutputFormat());
-    int n=0,nTotal=0;
-    n = fprintf(fp,format,_t);
-    if(n<0) {
+    // column[0]: timestamp
+    std::string line_buf = IO::FormatDouble(_t);
+
+    // column[1..num_states]: states
+    for(size_t i = 0; i < _data.getSize(); i++) {
+        line_buf += '\t';
+        line_buf += IO::FormatDouble(_data[i]);
+    }
+
+    // end of row
+    line_buf += '\n';
+
+    // write linebuf to output fd
+    int bytes_written = fwrite(line_buf.data(), 1, line_buf.size(), fp);
+    if (bytes_written < line_buf.size()) {
         log_error("StateVector.print(FILE*): error writing to file.");
-        return(n);
-    }
-    nTotal += n;
-
-    // STATES
-    sprintf(format,"\t%s",IO::GetDoubleOutputFormat());
-    for(int i=0;i<_data.getSize();i++) {
-        n = fprintf(fp,format,_data[i]);
-        if(n<0) {
-            log_error("StateVector.print(FILE*): error writing to file.");
-            return(n);
-        }
-        nTotal += n;
+        return -1;
     }
 
-    // CARRIAGE RETURN
-    n = fprintf(fp,"\n");
-    if(n<0) {
-        log_error("StateVector.print(FILE*): error writing to file.");
-        return(n);
-    }
-    nTotal += n;
-
-    return(nTotal);
+    return bytes_written;
 }

--- a/OpenSim/Simulation/Control/ControlLinearNode.cpp
+++ b/OpenSim/Simulation/Control/ControlLinearNode.cpp
@@ -21,8 +21,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/* Note: This code was originally developed by Realistic Dynamics Inc. 
- * Author: Frank C. Anderson 
+/* Note: This code was originally developed by Realistic Dynamics Inc.
+ * Author: Frank C. Anderson
  */
 #include <OpenSim/Common/IO.h>
 #include "ControlLinearNode.h"
@@ -40,7 +40,7 @@ using namespace OpenSim;
 //=============================================================================
 //_____________________________________________________________________________
 /**
- * Default constructor. 
+ * Default constructor.
  *
  * @param aT Time.
  * @param aX Control value.
@@ -286,20 +286,9 @@ getValue() const
 char* ControlLinearNode::
 toString()
 {
-    int size = 8*32; 
-    char *string = new char[size];
-    char tmp[128];
-    const char *format = IO::GetDoubleOutputFormat();
+   std::stringstream ss;
+   ss << "t=" << IO::FormatDouble(_t);
+   ss << "value=" << IO::FormatDouble(_value);
 
-    strcpy(string,"t=");
-    sprintf(tmp,format,_t);
-    strcat(string,tmp);
-
-    strcat(string," value=");
-    sprintf(tmp,format,_value);
-    strcat(string,tmp);
-
-    return(string);
+   return strdup(ss.str().c_str());
 }
-
-


### PR DESCRIPTION
This was something I was playing around with. I'm not playing with it any more because it turns out that StateVector is deprecated, or that we don't really care so much about the analysis output (e.g. because SCONE doesn't use it anyway).

Turns out, printing a StateVector can eat up a fair amount of time (e.g. 7-9 %). We probably shouldn't use StateVector, but my first instinct was to look into how printing is currently done.

The existing printing approach involves getting a `printf` format string from `IO` and then using that in `printf` calls. My first gut instinct is to change the api to be something like:

```c++
// might create a useless allocation
std::string format(double d);

// better: appends to some existing string (that can be recycled)
void format(double d, std::string& append_target);

// maybe best: appends to some output `ostreambuf`
void write(double d, std::ostream& o);
```

But the current implementation also allows callers to `SetScientificMode` etc. etc. Some of these function calls are unused in `opensim-core`, and I can't find any usages in `opensim-gui`, but god knows if they're used in the wild. My first instinct is to just rip out as much as possible from the API, which leaves setting the padding and setting the precision.

> 