### PR TITLE
Muscle FiberVelocityInfo and MuscleDynamicsInfo refactor

### DIFF
--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
@@ -494,9 +494,8 @@ void DeGrooteFregly2016Muscle::calcFiberVelocityInfo(
     SimTK::Real normTendonForce = SimTK::NaN;
     SimTK::Real normTendonForceDerivative = SimTK::NaN;
     if (!get_ignore_tendon_compliance()) {
-        if (m_isTendonDynamicsExplicit) {
-            normTendonForce = getNormalizedTendonForce(s);
-        } else {
+        normTendonForce = getNormalizedTendonForce(s);
+        if (!m_isTendonDynamicsExplicit) {
             normTendonForceDerivative = getNormalizedTendonForceDerivative(s);
         }
     }

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -187,7 +187,7 @@ public:
     /// If ignore_activation_dynamics is true, this gets excitation instead.
     double getActivation(const SimTK::State& s) const override {
         // We override the Muscle's implementation because Muscle requires
-        // realizing to Dynamics to access activation from MuscleDynamicsInfo,
+        // realizing to Dynamics to access activation from MuscleVelocityInfo,
         // which is unnecessary if the activation is a state.
         if (get_ignore_activation_dynamics()) {
             return getControl(s);

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -206,7 +206,6 @@ public:
             setStateVariableValue(s, STATE_ACTIVATION_NAME, activation);
         }
         markCacheVariableInvalid(s, "velInfo");
-        markCacheVariableInvalid(s, "dynamicsInfo");
     }
 
 protected:
@@ -216,8 +215,6 @@ protected:
             const SimTK::State& s, MuscleLengthInfo& mli) const override;
     void calcFiberVelocityInfo(
             const SimTK::State& s, FiberVelocityInfo& fvi) const override;
-    void calcMuscleDynamicsInfo(
-            const SimTK::State& s, MuscleDynamicsInfo& mdi) const override;
     void calcMusclePotentialEnergyInfo(const SimTK::State& s,
             MusclePotentialEnergyInfo& mpei) const override;
 
@@ -362,7 +359,6 @@ public:
                     s, STATE_NORMALIZED_TENDON_FORCE_NAME, normTendonForce);
             markCacheVariableInvalid(s, "lengthInfo");
             markCacheVariableInvalid(s, "velInfo");
-            markCacheVariableInvalid(s, "dynamicsInfo");
         }
     }
     /// @}
@@ -712,16 +708,13 @@ public:
 
         MuscleLengthInfo mli;
         FiberVelocityInfo fvi;
-        MuscleDynamicsInfo mdi;
         calcMuscleLengthInfoHelper(
                 muscleTendonLength, false, mli, normTendonForce);
         calcFiberVelocityInfoHelper(muscleTendonVelocity, activation, false,
                 false, mli, fvi, normTendonForce, normTendonForceDerivative);
-        calcMuscleDynamicsInfoHelper(activation, muscleTendonVelocity, false,
-                mli, fvi, mdi, normTendonForce);
 
-        return mdi.normTendonForce -
-               mdi.fiberForceAlongTendon / get_max_isometric_force();
+        return fvi.normTendonForce -
+               fvi.fiberForceAlongTendon / get_max_isometric_force();
     }
 
     /// The residual (i.e. error) in the time derivative of the linearized
@@ -740,17 +733,14 @@ public:
 
         MuscleLengthInfo mli;
         FiberVelocityInfo fvi;
-        MuscleDynamicsInfo mdi;
         calcMuscleLengthInfoHelper(
                 muscleTendonLength, false, mli, normTendonForce);
         calcFiberVelocityInfoHelper(muscleTendonVelocity, activation, false,
                 m_isTendonDynamicsExplicit, mli, fvi, normTendonForce,
                 normTendonForceDerivative);
-        calcMuscleDynamicsInfoHelper(activation, muscleTendonVelocity, false,
-                mli, fvi, mdi, normTendonForce);
 
-        return mdi.fiberStiffnessAlongTendon * fvi.fiberVelocityAlongTendon -
-               mdi.tendonStiffness *
+        return fvi.fiberStiffnessAlongTendon * fvi.fiberVelocityAlongTendon -
+               fvi.tendonStiffness *
                        (muscleTendonVelocity - fvi.fiberVelocityAlongTendon);
     }
     /// @}
@@ -821,11 +811,6 @@ private:
             const MuscleLengthInfo& mli, FiberVelocityInfo& fvi,
             const SimTK::Real& normTendonForce = SimTK::NaN,
             const SimTK::Real& normTendonForceDerivative = SimTK::NaN) const;
-    void calcMuscleDynamicsInfoHelper(const SimTK::Real& activation,
-            const SimTK::Real& muscleTendonVelocity,
-            const bool& ignoreTendonCompliance, const MuscleLengthInfo& mli,
-            const FiberVelocityInfo& fvi, MuscleDynamicsInfo& mdi,
-            const SimTK::Real& normTendonForce = SimTK::NaN) const;
     void calcMusclePotentialEnergyInfoHelper(const bool& ignoreTendonCompliance,
             const MuscleLengthInfo& mli, MusclePotentialEnergyInfo& mpei) const;
 
@@ -950,13 +935,13 @@ private:
     SimTK::Real m_kT = SimTK::NaN;
     bool m_isTendonDynamicsExplicit = true;
 
-    // Indices for MuscleDynamicsInfo::userDefinedDynamicsExtras.
-    constexpr static int m_mdi_passiveFiberElasticForce = 0;
-    constexpr static int m_mdi_passiveFiberDampingForce = 1;
-    constexpr static int m_mdi_partialPennationAnglePartialFiberLength = 2;
-    constexpr static int m_mdi_partialFiberForceAlongTendonPartialFiberLength =
+    // Indices for FiberVelocityInfo::userDefinedVelocityExtras.
+    constexpr static int m_fvi_passiveFiberElasticForce = 0;
+    constexpr static int m_fvi_passiveFiberDampingForce = 1;
+    constexpr static int m_fvi_partialPennationAnglePartialFiberLength = 2;
+    constexpr static int m_fvi_partialFiberForceAlongTendonPartialFiberLength =
             3;
-    constexpr static int m_mdi_partialTendonForcePartialFiberLength = 4;
+    constexpr static int m_fvi_partialTendonForcePartialFiberLength = 4;
 };
 
 } // namespace OpenSim

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -407,6 +407,7 @@ void Millard2012AccelerationMuscle::
 {
     setStateVariableValue(s, STATE_FIBER_LENGTH_NAME, fiberLength);
     markCacheVariableInvalid(s, _lengthInfoCV);
+    markCacheVariableInvalid(s, _forceMultipliersCV);
     markCacheVariableInvalid(s, _velInfoCV);
     
 }

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -248,7 +248,7 @@ Millard2012AccelerationMuscle(const std::string &aName,  double aMaxIsometricFor
     addStateVariable(STATE_FIBER_LENGTH_NAME);
     addStateVariable(STATE_FIBER_VELOCITY_NAME);
 
-    this->_forceMultipliers = addCacheVariable(
+    this->_forceMultipliersCV = addCacheVariable(
         "_forceMultipliers",
         Millard2012AccelerationMuscle::ForceMultipliersCV(),
         SimTK::Stage::Position);
@@ -363,14 +363,14 @@ double Millard2012AccelerationMuscle::
 const Millard2012AccelerationMuscle::ForceMultipliersCV&
 Millard2012AccelerationMuscle::getForceMultipliers(const SimTK::State& s) const
 {
-    if (isCacheVariableValid(s, _forceMultipliers)) {
-        return getCacheVariableValue(s, _forceMultipliers);
+    if (isCacheVariableValid(s, _forceMultipliersCV)) {
+        return getCacheVariableValue(s, _forceMultipliersCV);
     }
 
     ForceMultipliersCV& multipliers =
-        updCacheVariableValue(s, _forceMultipliers);
+        updCacheVariableValue(s, _forceMultipliersCV);
     calcForceMultipliers(s, multipliers);
-    markCacheVariableValid(s, _forceMultipliers);
+    markCacheVariableValid(s, _forceMultipliersCV);
     return multipliers;
 }
 

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -292,6 +292,28 @@ void Millard2012AccelerationMuscle::
 }
 
 //=============================================================================
+// HELPER FUNCTIONS
+//=============================================================================
+
+namespace
+{
+
+double calcFiberAcceleration(
+    double mass,
+    double fiberLength,
+    double cosPennationAngle,
+    double pennationAngularVelocity,
+    double tendonForce,
+    double fiberForceAlongTendon)
+{
+    return (1 / mass) * (tendonForce - fiberForceAlongTendon) *
+               cosPennationAngle +
+           fiberLength * pennationAngularVelocity * pennationAngularVelocity;
+}
+
+} // namespace
+
+//=============================================================================
 // STATE RELATED GET FUNCTIONS
 //=============================================================================
 
@@ -330,15 +352,14 @@ double Millard2012AccelerationMuscle::
 double Millard2012AccelerationMuscle::
     getFiberAcceleration(const SimTK::State& s) const
 {
-    const double m = getMass();
-
     const FiberVelocityInfoCache& fvi = getFiberVelocityInfo(s);
-    const double FceAT  = fvi.calcFiberForceAlongTendon();
-    const double Fse    = fvi.tendonForce;
-    const double lce    = fvi.fiberLength;
-    const double cosphi = fvi.cosPennationAngle;
-    const double dphidt = fvi.calcPennationAngularVelocity();
-    return (1/m)*(Fse-FceAT)*cosphi + lce*dphidt*dphidt;
+    return calcFiberAcceleration(
+        getMass(),
+        fvi.fiberLength,
+        fvi.cosPennationAngle,
+        fvi.calcPennationAngularVelocity(),
+        fvi.tendonForce,
+        fvi.calcFiberForceAlongTendon());
 }
 
 //=============================================================================

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.h
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.h
@@ -693,8 +693,9 @@ protected:
                about the muscle that is available at the velocity stage
 
     */
-    void calcFiberVelocityInfo(const SimTK::State& s, 
-                               FiberVelocityInfo& fvi) const override final;
+    void calcFiberVelocityInfo(const SimTK::State& s,
+                               const MuscleLengthInfo& mli,
+                               FiberVelocityInfo& fvi) const override;
 
     void calcMusclePotentialEnergyInfo(const SimTK::State& s,
         MusclePotentialEnergyInfo& mpei) const override final;

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.h
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.h
@@ -1137,7 +1137,7 @@ private:
         double tendonForceLengthMultiplier = SimTK::NaN;
     };
 
-    mutable CacheVariable<ForceMultipliersCV> _forceMultipliers;
+    mutable CacheVariable<ForceMultipliersCV> _forceMultipliersCV;
 
 };    
 

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.h
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.h
@@ -896,6 +896,25 @@ private:
                                           const AccelerationMuscleInfo& ami,
                                           std::string& caller) const;
 
+    struct ForceMultipliersCV;
+
+    /** Calculate muscle's force-multiplier values that are specific to this
+     * muscle .
+    @param s the state of the model
+    @param multipliers struct holding the computed multipliers
+    */
+    void calcForceMultipliers(
+        const SimTK::State& s,
+        ForceMultipliersCV& multipliers) const;
+
+    /** Calculate muscle's force-multiplier values that are specific to this
+     * muscle .
+    @param s the state of the model
+    @return struct containing the multipliers
+    */
+    const ForceMultipliersCV& getForceMultipliers(
+        const SimTK::State& s) const;
+
     // Status flag returned by initMuscleState().
     enum StatusFromInitMuscleState {
         Success_Converged,
@@ -1108,6 +1127,17 @@ private:
         }
     };
 
+    /**
+     * Struct used for caching extra force multiplier values specific to this
+     * muscle.
+    */
+    struct ForceMultipliersCV {
+        double fiberCompressiveForceLengthMultiplier = SimTK::NaN;
+        double fiberCompressiveCosPennationMultiplier = SimTK::NaN;
+        double tendonForceLengthMultiplier = SimTK::NaN;
+    };
+
+    mutable CacheVariable<ForceMultipliersCV> _forceMultipliers;
 
 };    
 

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.h
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.h
@@ -640,8 +640,8 @@ public:
         
 ///@cond DEPRECATED
     /*  Once the ignore_tendon_compliance flag is implemented correctly get rid 
-        of this method as it duplicates code in calcMuscleLengthInfo,
-        calcFiberVelocityInfo, and calcMuscleDynamicsInfo
+        of this method as it duplicates code in calcMuscleLengthInfo and
+        calcFiberVelocityInfo.
     */
     double calcInextensibleTendonActiveFiberForce(SimTK::State& s, 
                                        double aActivation) const override final;
@@ -695,16 +695,6 @@ protected:
     */
     void calcFiberVelocityInfo(const SimTK::State& s, 
                                FiberVelocityInfo& fvi) const override final;
-
-    /** calculate muscle's active and passive force-length, force-velocity, 
-        tendon force, relationships and their related values 
-    @param s the state of the model
-    @param mdi the muscle dynamics info struct that will hold updated 
-            information about the muscle that is available at the dynamics stage    
-    */
-    void calcMuscleDynamicsInfo(const SimTK::State& s, 
-                                 MuscleDynamicsInfo& mdi) const override final;
-
 
     void calcMusclePotentialEnergyInfo(const SimTK::State& s,
         MusclePotentialEnergyInfo& mpei) const override final;

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
@@ -447,8 +447,8 @@ public:
 //==============================================================================
     ///@cond DEPRECATED
     /*  Once the ignore_tendon_compliance flag is implemented correctly, get rid
-    of this method as it duplicates code in calcMuscleLengthInfo,
-    calcFiberVelocityInfo, and calcMuscleDynamicsInfo.
+    of this method as it duplicates code in calcMuscleLengthInfo and
+    calcFiberVelocityInfo.
         @param activation of the muscle [0-1]
         @param fiberLength in (m)
         @param fiberVelocity in (m/s)
@@ -522,14 +522,6 @@ protected:
     velocity, etc.). */
     void calcFiberVelocityInfo(const SimTK::State& s,
                                FiberVelocityInfo& fvi) const override;
-
-    /** Calculate the dynamics-related values associated with the muscle state
-    (from the active- and passive-force-length curves, the force-velocity curve,
-    and the tendon-force-length curve). The last entry is a SimTK::Vector
-    containing the passive conservative (elastic) fiber force and the passive
-    non-conservative (damping) fiber force. */
-    void calcMuscleDynamicsInfo(const SimTK::State& s,
-                                MuscleDynamicsInfo& mdi) const override;
 
     /** Calculate the potential energy values associated with the muscle */
     void  calcMusclePotentialEnergyInfo(const SimTK::State& s, 

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
@@ -521,6 +521,7 @@ protected:
     (fiber and tendon velocities, normalized velocities, pennation angular
     velocity, etc.). */
     void calcFiberVelocityInfo(const SimTK::State& s,
+                               const MuscleLengthInfo& mli,
                                FiberVelocityInfo& fvi) const override;
 
     /** Calculate the potential energy values associated with the muscle */

--- a/OpenSim/Actuators/RigidTendonMuscle.cpp
+++ b/OpenSim/Actuators/RigidTendonMuscle.cpp
@@ -138,12 +138,6 @@ calcMuscleLengthInfo(const State& s, MuscleLengthInfo& mli) const
     mli.pennationAngle = acos(mli.cosPennationAngle);
     mli.normFiberLength = mli.fiberLength/getOptimalFiberLength();
 
-    const Vector arg(1, mli.normFiberLength);
-    mli.fiberActiveForceLengthMultiplier = 
-        get_active_force_length_curve().calcValue(arg);
-    mli.fiberPassiveForceLengthMultiplier = 
-        SimTK::clamp(0, get_passive_force_length_curve().calcValue(arg), 10);
-
     mli.normTendonLength = 1.0;
     mli.tendonStrain = 0.0;
 }
@@ -160,43 +154,39 @@ void RigidTendonMuscle::calcMusclePotentialEnergyInfo(const SimTK::State& s,
     normalized velocities, pennation angular velocity, etc... */
 void RigidTendonMuscle::calcFiberVelocityInfo(const State& s, FiberVelocityInfo& fvi) const
 {
-    /*const MuscleLengthInfo &mli = */getMuscleLengthInfo(s);
+    const MuscleLengthInfo &mli = getMuscleLengthInfo(s);
     fvi.fiberVelocity = getPath().getLengtheningSpeed(s);
     fvi.normFiberVelocity = fvi.fiberVelocity / 
                             (getOptimalFiberLength()*getMaxContractionVelocity());
     fvi.fiberForceVelocityMultiplier = 
         get_force_velocity_curve().calcValue(Vector(1, fvi.normFiberVelocity));
-}
 
-/* calculate muscle's active and passive force-length, force-velocity, 
-    tendon force, relationships and their related values */
-void RigidTendonMuscle::
-calcMuscleDynamicsInfo(const State& s, MuscleDynamicsInfo& mdi) const
-{
-    const MuscleLengthInfo &mli = getMuscleLengthInfo(s);
-    const FiberVelocityInfo &fvi = getFiberVelocityInfo(s);
+    const Vector arg(1, mli.normFiberLength);
+    fvi.fiberActiveForceLengthMultiplier =
+        get_active_force_length_curve().calcValue(arg);
+    fvi.fiberPassiveForceLengthMultiplier =
+        SimTK::clamp(0, get_passive_force_length_curve().calcValue(arg), 10);
 
-    mdi.activation = getControl(s);
-    double normActiveForce = mdi.activation 
-                             * mli.fiberActiveForceLengthMultiplier 
+    fvi.activation = getControl(s);
+    double normActiveForce = fvi.activation 
+                             * fvi.fiberActiveForceLengthMultiplier
                              * fvi.fiberForceVelocityMultiplier;
-    mdi.activeFiberForce =  getMaxIsometricForce()*normActiveForce;
-    mdi.passiveFiberForce = getMaxIsometricForce()
-                            * mli.fiberPassiveForceLengthMultiplier;
-    mdi.fiberForce = mdi.activeFiberForce + mdi.passiveFiberForce;
-    mdi.fiberForceAlongTendon = mdi.fiberForce*mli.cosPennationAngle;
-    mdi.tendonForce = mdi.fiberForceAlongTendon;
+    fvi.activeFiberForce =  getMaxIsometricForce()*normActiveForce;
+    fvi.passiveFiberForce = getMaxIsometricForce()
+                            * fvi.fiberPassiveForceLengthMultiplier;
+    fvi.fiberForce = fvi.activeFiberForce + fvi.passiveFiberForce;
+    fvi.fiberForceAlongTendon = fvi.fiberForce*mli.cosPennationAngle;
+    fvi.tendonForce = fvi.fiberForceAlongTendon;
 
-    mdi.normTendonForce = (normActiveForce+mli.fiberPassiveForceLengthMultiplier)
+    fvi.normTendonForce = (normActiveForce+fvi.fiberPassiveForceLengthMultiplier)
                           * mli.cosPennationAngle;
 
-    mdi.fiberActivePower = -(mdi.activeFiberForce) * fvi.fiberVelocity;
-    mdi.fiberPassivePower = -(mdi.passiveFiberForce) * fvi.fiberVelocity;
-    mdi.tendonPower = 0;
-    mdi.musclePower = -getMaxIsometricForce()*mdi.normTendonForce
+    fvi.fiberActivePower = -(fvi.activeFiberForce) * fvi.fiberVelocity;
+    fvi.fiberPassivePower = -(fvi.passiveFiberForce) * fvi.fiberVelocity;
+    fvi.tendonPower = 0;
+    fvi.musclePower = -getMaxIsometricForce()*fvi.normTendonForce
                         * fvi.fiberVelocity;
 }
-
 
 //--------------------------------------------------------------------------
 // COMPUTATIONS

--- a/OpenSim/Actuators/RigidTendonMuscle.h
+++ b/OpenSim/Actuators/RigidTendonMuscle.h
@@ -91,7 +91,10 @@ protected:
 
     /** calculate muscle's velocity related values such fiber and tendon velocities,
         normalized velocities, pennation angular velocity, etc... */
-    void  calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi) const override;
+    void  calcFiberVelocityInfo(
+            const SimTK::State& s,
+            const MuscleLengthInfo& mli,
+            FiberVelocityInfo& fvi) const override;
 
     /** calculate muscle's fiber and tendon potential energy */
     void calcMusclePotentialEnergyInfo(const SimTK::State& s,

--- a/OpenSim/Actuators/RigidTendonMuscle.h
+++ b/OpenSim/Actuators/RigidTendonMuscle.h
@@ -93,10 +93,6 @@ protected:
         normalized velocities, pennation angular velocity, etc... */
     void  calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi) const override;
 
-    /** calculate muscle's active and passive force-length, force-velocity, 
-        tendon force, relationships and their related values */
-    void  calcMuscleDynamicsInfo(const SimTK::State& s, MuscleDynamicsInfo& mdi) const override;
-
     /** calculate muscle's fiber and tendon potential energy */
     void calcMusclePotentialEnergyInfo(const SimTK::State& s,
         MusclePotentialEnergyInfo& mpei) const override;

--- a/OpenSim/Actuators/Test/testDeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/Test/testDeGrooteFregly2016Muscle.cpp
@@ -247,9 +247,6 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
             CHECK(muscle.getFiberLengthAlongTendon(state) ==
                     Approx(muscle.get_optimal_fiber_length()));
             CHECK(muscle.getTendonStrain(state) == 0.0);
-            CHECK(muscle.getPassiveForceMultiplier(state) ==
-                    Approx(muscle.calcPassiveForceMultiplier(1.0)));
-            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(1.0));
             const auto fiberPotentialEnergy =
                     muscle.calcPassiveForceMultiplierIntegral(1.0) *
                     muscle.get_optimal_fiber_length() *
@@ -263,6 +260,9 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
                     Approx(fiberPotentialEnergy + tendonPotentialEnergy));
 
             model.realizeVelocity(state);
+            CHECK(muscle.getPassiveForceMultiplier(state) ==
+                    Approx(muscle.calcPassiveForceMultiplier(1.0)));
+            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(1.0));
             CHECK(muscle.getFiberVelocity(state) == 0);
             CHECK(muscle.getNormalizedFiberVelocity(state) == 0);
             CHECK(muscle.getFiberVelocityAlongTendon(state) == 0);
@@ -357,10 +357,6 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
             CHECK(muscle.getFiberLengthAlongTendon(state) ==
                     Approx(0.5 * muscle.get_optimal_fiber_length()));
             CHECK(muscle.getTendonStrain(state) == 0.0);
-            CHECK(muscle.getPassiveForceMultiplier(state) ==
-                    Approx(muscle.calcPassiveForceMultiplier(0.5)));
-            CHECK(muscle.getActiveForceLengthMultiplier(state) ==
-                    Approx(muscle.calcActiveForceLengthMultiplier(0.5)));
             const auto fiberPotentialEnergy =
                     muscle.calcPassiveForceMultiplierIntegral(0.5) *
                     muscle.get_optimal_fiber_length() *
@@ -374,6 +370,10 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
                     Approx(fiberPotentialEnergy + tendonPotentialEnergy));
 
             model.realizeVelocity(state);
+            CHECK(muscle.getPassiveForceMultiplier(state) ==
+                    Approx(muscle.calcPassiveForceMultiplier(0.5)));
+            CHECK(muscle.getActiveForceLengthMultiplier(state) ==
+                    Approx(muscle.calcActiveForceLengthMultiplier(0.5)));
             CHECK(muscle.getFiberVelocity(state) == 0);
             CHECK(muscle.getNormalizedFiberVelocity(state) == 0);
             CHECK(muscle.getFiberVelocityAlongTendon(state) == 0);
@@ -449,9 +449,6 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
             CHECK(muscle.getFiberLengthAlongTendon(state) ==
                     Approx(muscle.get_optimal_fiber_length()));
             CHECK(muscle.getTendonStrain(state) == 0.0);
-            CHECK(muscle.getPassiveForceMultiplier(state) ==
-                    Approx(muscle.calcPassiveForceMultiplier(1.0)));
-            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(1.0));
             const auto fiberPotentialEnergy =
                     muscle.calcPassiveForceMultiplierIntegral(1.0) *
                     muscle.get_optimal_fiber_length() *
@@ -465,6 +462,9 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
                     Approx(fiberPotentialEnergy + tendonPotentialEnergy));
 
             model.realizeVelocity(state);
+            CHECK(muscle.getPassiveForceMultiplier(state) ==
+                    Approx(muscle.calcPassiveForceMultiplier(1.0)));
+            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(1.0));
             CHECK(muscle.getFiberVelocity(state) == 0.21 * Vmax);
             CHECK(muscle.getNormalizedFiberVelocity(state) == 0.21);
             CHECK(muscle.getFiberVelocityAlongTendon(state) == 0.21 * Vmax);
@@ -575,9 +575,6 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
             CHECK(muscle.getFiberLengthAlongTendon(state) ==
                     Approx(muscle.get_optimal_fiber_length()));
             CHECK(muscle.getTendonStrain(state) == 0.0);
-            CHECK(muscle.getPassiveForceMultiplier(state) ==
-                    Approx(muscle.calcPassiveForceMultiplier(1.0)));
-            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(1.0));
             const auto fiberPotentialEnergy =
                     muscle.calcPassiveForceMultiplierIntegral(1.0) *
                     muscle.get_optimal_fiber_length() *
@@ -591,6 +588,9 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
                     Approx(fiberPotentialEnergy + tendonPotentialEnergy));
 
             model.realizeVelocity(state);
+            CHECK(muscle.getPassiveForceMultiplier(state) ==
+                    Approx(muscle.calcPassiveForceMultiplier(1.0)));
+            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(1.0));
             CHECK(muscle.getFiberVelocity(state) == -1.0 * Vmax);
             CHECK(muscle.getNormalizedFiberVelocity(state) == -1);
             CHECK(muscle.getFiberVelocityAlongTendon(state) == -1 * Vmax);
@@ -745,9 +745,6 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
             CHECK(muscle.getFiberLengthAlongTendon(state) ==
                     Approx(muscle.get_optimal_fiber_length() * cosPenn));
             CHECK(muscle.getTendonStrain(state) == 0.0);
-            CHECK(muscle.getPassiveForceMultiplier(state) ==
-                    Approx(muscle.calcPassiveForceMultiplier(1.0)));
-            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(1.0));
             const auto fiberPotentialEnergy =
                     muscle.calcPassiveForceMultiplierIntegral(1.0) *
                     muscle.get_optimal_fiber_length() *
@@ -761,6 +758,9 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
                     Approx(fiberPotentialEnergy + tendonPotentialEnergy));
 
             model.realizeVelocity(state);
+            CHECK(muscle.getPassiveForceMultiplier(state) ==
+                    Approx(muscle.calcPassiveForceMultiplier(1.0)));
+            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(1.0));
             CHECK(muscle.getFiberVelocity(state) == -Vmax * cosPenn);
             CHECK(muscle.getNormalizedFiberVelocity(state) == -cosPenn);
             CHECK(muscle.getFiberVelocityAlongTendon(state) == -Vmax); // VMT
@@ -917,8 +917,6 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
             CHECK(muscle.getFiberLengthAlongTendon(state) ==
                     Approx(fiberLengthAlongTendon));
             CHECK(muscle.getTendonStrain(state) == Approx(tendonStrain));
-            CHECK(muscle.getPassiveForceMultiplier(state) == Approx(fpass));
-            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(fal));
             const auto fiberPotentialEnergy =
                     muscle.calcPassiveForceMultiplierIntegral(normFiberLength) *
                     muscle.get_optimal_fiber_length() *
@@ -935,6 +933,8 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
                     Approx(fiberPotentialEnergy + tendonPotentialEnergy));
 
             model.realizeVelocity(state);
+            CHECK(muscle.getPassiveForceMultiplier(state) == Approx(fpass));
+            CHECK(muscle.getActiveForceLengthMultiplier(state) == Approx(fal));
             const auto& normFiberVelocity =
                     muscle.getNormalizedFiberVelocity(state);
             const auto& fiberVelocity = Vmax * normFiberVelocity;

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -324,9 +324,9 @@ double Thelen2003Muscle::
 
 double  Thelen2003Muscle::computeActuation(const SimTK::State& s) const
 {
-    const MuscleDynamicsInfo& mdi = getMuscleDynamicsInfo(s);
-    setActuation(s, mdi.tendonForce);
-    return( mdi.tendonForce );
+    const double tendonForce = getFiberVelocityInfo(s).tendonForce;
+    setActuation(s, tendonForce);
+    return tendonForce;
 }
 
 void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
@@ -404,11 +404,6 @@ void Thelen2003Muscle::calcMuscleLengthInfo(const SimTK::State& s,
                                     mli.fiberLength,mclLength );
         mli.normTendonLength  = mli.tendonLength / tendonSlackLen;
         mli.tendonStrain      = mli.normTendonLength -  1.0;
-        
-
-    
-        mli.fiberPassiveForceLengthMultiplier= calcfpe(mli.normFiberLength);
-        mli.fiberActiveForceLengthMultiplier = calcfal(mli.normFiberLength);
     }catch(const std::exception &x){
         std::string msg = "Exception caught in Thelen2003Muscle::" 
                           "calcMuscleLengthInfo\n"                 
@@ -450,6 +445,9 @@ void Thelen2003Muscle::calcFiberVelocityInfo(const SimTK::State& s,
             // double mclLength      = getLength(s);
             double tendonSlackLen = getTendonSlackLength();
             double optFiberLen    = getOptimalFiberLength();
+        double fiso      = getMaxIsometricForce();
+        double penHeight = getPennationModel().getParallelogramHeight();
+
         //=========================================================================
         // Compute fv by inverting the force-velocity relationship in the 
         // equilibrium equations
@@ -501,8 +499,8 @@ void Thelen2003Muscle::calcFiberVelocityInfo(const SimTK::State& s,
         //to its minimum allowable value.
 
         double fse  = calcfse(tl/tendonSlackLen);    
-        double fal  = mli.fiberActiveForceLengthMultiplier;
-        double fpe  = mli.fiberPassiveForceLengthMultiplier;
+        double fal  = calcfal(mli.normFiberLength);
+        double fpe  = calcfpe(mli.normFiberLength);
 
         double afalfv = ((fse/cosphi)-fpe); //we can do this without fear of
                                               //a singularity because fiber length
@@ -543,67 +541,15 @@ void Thelen2003Muscle::calcFiberVelocityInfo(const SimTK::State& s,
         fvi.normTendonVelocity          = dtl/getTendonSlackLength();
 
         fvi.fiberForceVelocityMultiplier = fv;
-
-        fvi.userDefinedVelocityExtras.resize(2);
-        fvi.userDefinedVelocityExtras[0]=fse;
-        fvi.userDefinedVelocityExtras[1]=fiberStateClamped;
-    }
-    catch(const std::exception &x){
-        std::string msg = "Exception caught in Thelen2003Muscle::" 
-                            "calcFiberVelocityInfo\n"                 
-                            "of " + getName()  + "\n"                            
-                            + x.what();
-        throw OpenSim::Exception(msg);
-    }
-}
-
-
-//=======================================
-// computeFiberVelocityInfo helper functions
-//=======================================
-
-void Thelen2003Muscle::calcMuscleDynamicsInfo(const SimTK::State& s, 
-                                               MuscleDynamicsInfo& mdi) const
-{
-    try {
-        //Get the quantities that we've already computed
-        const MuscleLengthInfo &mli = getMuscleLengthInfo(s);
-        const FiberVelocityInfo &mvi = getFiberVelocityInfo(s);
-        //Get the static properties of this muscle
-        // double mclLength      = getLength(s);
-        double tendonSlackLen = getTendonSlackLength();
-        double optFiberLen    = getOptimalFiberLength();
-        double fiso           = getMaxIsometricForce();
-        double penHeight      = getPennationModel().getParallelogramHeight();
+        fvi.fiberPassiveForceLengthMultiplier = fpe;
+        fvi.fiberActiveForceLengthMultiplier = fal;
 
         //=========================================================================
-        // Compute required quantities
+        // Compute force related quantities.
         //=========================================================================
-        //1. Get fiber/tendon kinematic information
-        double a = getActivationModel().clampActivation(
-                       getStateVariableValue(s, STATE_ACTIVATION_PATH) );
-
-        double lce      = mli.fiberLength;
-        double fiberStateClamped = mvi.userDefinedVelocityExtras[1];
-        double dlce     = mvi.fiberVelocity;
-        double phi      = mli.pennationAngle;
-        double cosphi   = mli.cosPennationAngle;
-        // double sinphi   = mli.sinPennationAngle;
-
-        double tl   = mli.tendonLength; 
-        double dtl  = mvi.tendonVelocity;
-        // double tlN  = mli.normTendonLength;
 
         //Default values appropriate when the fiber is clamped to its minimum length
         //and is generating no force
-
-        //These quantities should already be set to legal values from
-        //calcFiberVelocityInfo
-        double fal  = mli.fiberActiveForceLengthMultiplier;
-        double fpe  = mli.fiberPassiveForceLengthMultiplier;
-        double fv   = mvi.fiberForceVelocityMultiplier;
-        double fse  = mvi.userDefinedVelocityExtras[0];
-    
         double aFm          = 0; //active fiber force
         double Fm           = 0;
         double dFm_dlce     = 0;
@@ -627,54 +573,52 @@ void Thelen2003Muscle::calcMuscleDynamicsInfo(const SimTK::State& s,
             //Compute the stiffness of the whole muscle/tendon complex
             Ke = (dFmAT_dlceAT*dFt_dtl)/(dFmAT_dlceAT+dFt_dtl);
         }
-    
-        mdi.activation                   = a;
-        mdi.fiberForce                   = Fm; 
-        mdi.fiberForceAlongTendon        = Fm*cosphi;
-        mdi.normFiberForce               = Fm/fiso;
-        mdi.activeFiberForce             = aFm;
-        mdi.passiveFiberForce            = fpe*fiso;
-                                     
-        mdi.tendonForce                  = fse*fiso;
-        mdi.normTendonForce              = fse;
-                                     
-        mdi.fiberStiffness               = dFm_dlce;
-        mdi.fiberStiffnessAlongTendon    = dFmAT_dlceAT;
-        mdi.tendonStiffness              = dFt_dtl;
-        mdi.muscleStiffness              = Ke;
-                                     
-    
+
+        fvi.activation                   = a;
+        fvi.fiberForce                   = Fm; 
+        fvi.fiberForceAlongTendon        = Fm*cosphi;
+        fvi.normFiberForce               = Fm/fiso;
+        fvi.activeFiberForce             = aFm;
+        fvi.passiveFiberForce            = fpe*fiso;
+
+        fvi.tendonForce                  = fse*fiso;
+        fvi.normTendonForce              = fse;
+
+        fvi.fiberStiffness               = dFm_dlce;
+        fvi.fiberStiffnessAlongTendon    = dFmAT_dlceAT;
+        fvi.tendonStiffness              = dFt_dtl;
+        fvi.muscleStiffness              = Ke;
+
+
 
         //Check that the derivative of system energy less work is zero within
         //a reasonable numerical tolerance. Throw an exception if this is not true    
         double dFibPEdt     = fpe*fiso*dlce;
         double dTdnPEdt     = fse*fiso*dtl;
-        double dFibWdt      = -mdi.activeFiberForce*mvi.fiberVelocity;
-        double dmcldt       = getLengtheningSpeed(s);
-        double dBoundaryWdt = mdi.tendonForce * dmcldt;
-        double ddt_KEPEmW   = dFibPEdt+dTdnPEdt-dFibWdt-dBoundaryWdt;
-        SimTK::Vector userVec(1);
-        userVec(0) = ddt_KEPEmW;  
-        mdi.userDefinedDynamicsExtras = userVec;
+        double dFibWdt      = -fvi.activeFiberForce*fvi.fiberVelocity;
+        double dBoundaryWdt = fvi.tendonForce * dmcldt;
 
         /////////////////////////////
         //Populate the power entries
         /////////////////////////////
-        mdi.fiberActivePower             = dFibWdt;
-        mdi.fiberPassivePower            = -dFibPEdt;
-        mdi.tendonPower                  = -dTdnPEdt;       
-        mdi.musclePower                  = -dBoundaryWdt;
-
+        fvi.fiberActivePower             = dFibWdt;
+        fvi.fiberPassivePower            = -dFibPEdt;
+        fvi.tendonPower                  = -dTdnPEdt;       
+        fvi.musclePower                  = -dBoundaryWdt;
     }
-    catch(const std::exception &x) {
+    catch(const std::exception &x){
         std::string msg = "Exception caught in Thelen2003Muscle::" 
-                            "calcMuscleDynamicsInfo\n"                 
+                            "calcFiberVelocityInfo\n"                 
                             "of " + getName()  + "\n"                            
                             + x.what();
         throw OpenSim::Exception(msg);
     }
-   
 }
+
+
+//=======================================
+// computeFiberVelocityInfo helper functions
+//=======================================
 
 double Thelen2003Muscle::getMinimumFiberLength() const
 {

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -196,6 +196,12 @@ void Thelen2003Muscle::constructProperties()
 //=============================================================================
 // GET
 //=============================================================================
+double Thelen2003Muscle::getActivation(const SimTK::State& s) const
+{
+    return getActivationModel().clampActivation(getStateVariableValue(
+                s,
+                STATE_ACTIVATION_PATH));
+}
 double Thelen2003Muscle::getActivationTimeConstant() const
 {   return get_activation_time_constant(); }
 
@@ -456,8 +462,7 @@ void Thelen2003Muscle::calcFiberVelocityInfo(const SimTK::State& s,
         //1. Get fiber/tendon kinematic information
 
         //clamp activation to a legal range
-        double a = getActivationModel().clampActivation(getStateVariableValue(s,
-                                          STATE_ACTIVATION_PATH));
+        double a = getActivation(s);
    
 
         double lce  = mli.fiberLength;   

--- a/OpenSim/Actuators/Thelen2003Muscle.h
+++ b/OpenSim/Actuators/Thelen2003Muscle.h
@@ -230,8 +230,8 @@ public:
        
     ///@cond DEPRECATED
     /*  Once the ignore_tendon_compliance flag is implemented correctly get rid 
-        of this method as it duplicates code in calcMuscleLengthInfo,
-        calcFiberVelocityInfo, and calcMuscleDynamicsInfo
+        of this method as it duplicates code in calcMuscleLengthInfo and
+        calcFiberVelocityInfo
     */
     /*
     @param activation of the muscle [0-1]
@@ -263,11 +263,6 @@ protected:
         velocities,normalized velocities, pennation angular velocity, etc... */
     void  calcFiberVelocityInfo(const SimTK::State& s, 
                                       FiberVelocityInfo& fvi) const override; 
-
-    /** calculate muscle's active and passive force-length, force-velocity, 
-        tendon force, relationships and their related values */
-    void  calcMuscleDynamicsInfo(const SimTK::State& s, 
-                                    MuscleDynamicsInfo& mdi) const override;
 
     /** calculate muscle's fiber and tendon potential energy */
     void calcMusclePotentialEnergyInfo(const SimTK::State& s,

--- a/OpenSim/Actuators/Thelen2003Muscle.h
+++ b/OpenSim/Actuators/Thelen2003Muscle.h
@@ -263,7 +263,8 @@ protected:
     /** calculate muscle's velocity related values such fiber and tendon 
         velocities,normalized velocities, pennation angular velocity, etc... */
     void  calcFiberVelocityInfo(const SimTK::State& s, 
-                                      FiberVelocityInfo& fvi) const override; 
+                                const MuscleLengthInfo& mli,
+                                FiberVelocityInfo& fvi) const override;
 
     /** calculate muscle's fiber and tendon potential energy */
     void calcMusclePotentialEnergyInfo(const SimTK::State& s,

--- a/OpenSim/Actuators/Thelen2003Muscle.h
+++ b/OpenSim/Actuators/Thelen2003Muscle.h
@@ -175,6 +175,7 @@ public:
     These are convenience methods that get and set properties of the activation
     and pennation models. **/
     /**@{**/
+    double getActivation(const SimTK::State& s) const override;
     double getActivationTimeConstant() const;
     void setActivationTimeConstant(double actTimeConstant);
     double getDeactivationTimeConstant() const;

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle.cpp
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle.cpp
@@ -165,7 +165,6 @@ void ActivationFiberLengthMuscle::setFiberLength(SimTK::State& s, double fiberLe
     // invalidate the length info whenever fiber length is set.
     markCacheVariableInvalid(s, _lengthInfoCV);
     markCacheVariableInvalid(s, _velInfoCV);
-    markCacheVariableInvalid(s, _dynamicsInfoCV);
 }
 
 double ActivationFiberLengthMuscle::getActivationRate(const SimTK::State& s) const

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.cpp
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.cpp
@@ -500,24 +500,26 @@ void ActivationFiberLengthMuscle_Deprecated::calcMuscleLengthInfo(const SimTK::S
 
 /* calculate muscle's velocity related values such fiber and tendon velocities,
     normalized velocities, pennation angular velocity, etc... */
-void ActivationFiberLengthMuscle_Deprecated::calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi) const
+void ActivationFiberLengthMuscle_Deprecated::calcFiberVelocityInfo(
+        const SimTK::State& s,
+        const MuscleLengthInfo& mli,
+        FiberVelocityInfo& fvi) const
 {
 
     fvi.fiberVelocity = getFiberLengthDeriv(s);
-    fvi.normFiberVelocity = fvi.fiberVelocity/(getOptimalFiberLength()*getMaxContractionVelocity());
 
-    const MuscleLengthInfo &mli = getMuscleLengthInfo(s);
     const double &maxIsometricForce = getMaxIsometricForce();
 
     fvi.fiberActiveForceLengthMultiplier = calcActiveForce(s, mli.normFiberLength);
     fvi.fiberPassiveForceLengthMultiplier = calcPassiveForce(s, mli.normFiberLength);
 
-    double tendonForce = getActuation(s);
-    fvi.normTendonForce = tendonForce/maxIsometricForce;
+    fvi.tendonForce = getActuation(s);
     
-    fvi.passiveFiberForce = fvi.fiberPassiveForceLengthMultiplier * maxIsometricForce;
+    fvi.passiveElasticFiberForce = fvi.fiberPassiveForceLengthMultiplier * maxIsometricForce;
+    fvi.passiveDampingFiberForce = 0.;
     
     fvi.activation = getStateVariableValue(s, STATE_ACTIVATION_NAME);
 
-    fvi.activeFiberForce =  tendonForce/mli.cosPennationAngle - fvi.passiveFiberForce;
+    fvi.activeFiberForce =  fvi.tendonForce/mli.cosPennationAngle
+        - fvi.passiveElasticFiberForce;
 }

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.cpp
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.cpp
@@ -496,32 +496,28 @@ void ActivationFiberLengthMuscle_Deprecated::calcMuscleLengthInfo(const SimTK::S
     mli.normFiberLength = mli.fiberLength/getOptimalFiberLength();
     mli.normTendonLength = norm_muscle_tendon_length - mli.normFiberLength * mli.cosPennationAngle;
     mli.tendonStrain = (mli.tendonLength/getTendonSlackLength()-1.0);
-
-    mli.fiberActiveForceLengthMultiplier = calcActiveForce(s, mli.normFiberLength);
-    mli.fiberPassiveForceLengthMultiplier = calcPassiveForce(s, mli.normFiberLength);
 }
 
 /* calculate muscle's velocity related values such fiber and tendon velocities,
     normalized velocities, pennation angular velocity, etc... */
 void ActivationFiberLengthMuscle_Deprecated::calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi) const
 {
+
     fvi.fiberVelocity = getFiberLengthDeriv(s);
     fvi.normFiberVelocity = fvi.fiberVelocity/(getOptimalFiberLength()*getMaxContractionVelocity());
-}
 
-/* calculate muscle's active and passive force-length, force-velocity, 
-    tendon force, relationships and their related values */
-void ActivationFiberLengthMuscle_Deprecated::calcMuscleDynamicsInfo(const SimTK::State& s, MuscleDynamicsInfo& mdi) const
-{
     const MuscleLengthInfo &mli = getMuscleLengthInfo(s);
     const double &maxIsometricForce = getMaxIsometricForce();
 
-    double tendonForce = getActuation(s);
-    mdi.normTendonForce = tendonForce/maxIsometricForce;
-    
-    mdi.passiveFiberForce = mli.fiberPassiveForceLengthMultiplier * maxIsometricForce;
-    
-    mdi.activation = getStateVariableValue(s, STATE_ACTIVATION_NAME);
+    fvi.fiberActiveForceLengthMultiplier = calcActiveForce(s, mli.normFiberLength);
+    fvi.fiberPassiveForceLengthMultiplier = calcPassiveForce(s, mli.normFiberLength);
 
-    mdi.activeFiberForce =  tendonForce/mli.cosPennationAngle - mdi.passiveFiberForce;
+    double tendonForce = getActuation(s);
+    fvi.normTendonForce = tendonForce/maxIsometricForce;
+    
+    fvi.passiveFiberForce = fvi.fiberPassiveForceLengthMultiplier * maxIsometricForce;
+    
+    fvi.activation = getStateVariableValue(s, STATE_ACTIVATION_NAME);
+
+    fvi.activeFiberForce =  tendonForce/mli.cosPennationAngle - fvi.passiveFiberForce;
 }

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.h
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.h
@@ -151,7 +151,6 @@ protected:
     // Muscle interface
     void calcMuscleLengthInfo(const SimTK::State& s, MuscleLengthInfo& mli) const override;
     void calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi) const override;
-    void calcMuscleDynamicsInfo(const SimTK::State& s, MuscleDynamicsInfo& mdi) const override;
 
     virtual double calcActiveForce(const SimTK::State& s, double aNormFiberLength) const
     {

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.h
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.h
@@ -150,7 +150,10 @@ protected:
 
     // Muscle interface
     void calcMuscleLengthInfo(const SimTK::State& s, MuscleLengthInfo& mli) const override;
-    void calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi) const override;
+    void calcFiberVelocityInfo(
+            const SimTK::State& s,
+            const MuscleLengthInfo& mli,
+            FiberVelocityInfo& fvi) const override;
 
     virtual double calcActiveForce(const SimTK::State& s, double aNormFiberLength) const
     {

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -602,6 +602,16 @@ void Muscle::calcFiberVelocityInfo(
         + "::calcFiberVelocityInfo() NOT IMPLEMENTED.");
 }
 
+void Muscle::calcFiberVelocityInfoCache(
+    const SimTK::State& s,
+    FiberVelocityInfoCache& fvi) const
+{
+    MuscleLengthInfo& mli = fvi;
+    // Copy the length info fields.
+    mli = getMuscleLengthInfo(s);
+    calcFiberVelocityInfo(s, mli, fvi);
+}
+
 /* calculate muscle's fiber and tendon potential energy */
 void Muscle::calcMusclePotentialEnergyInfo(const SimTK::State& s,
     MusclePotentialEnergyInfo& mpei) const

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -228,7 +228,6 @@ void Muscle::extendConnectToModel(Model& aModel)
     //              velocity in the reduced model.
     this->_lengthInfoCV = addCacheVariable("lengthInfo", MuscleLengthInfo(), SimTK::Stage::Velocity);
     this->_velInfoCV = addCacheVariable("velInfo", FiberVelocityInfo(), SimTK::Stage::Velocity);
-    this->_dynamicsInfoCV = addCacheVariable("dynamicsInfo", MuscleDynamicsInfo(), SimTK::Stage::Dynamics);
     this->_potentialEnergyInfoCV = addCacheVariable("potentialEnergyInfo", MusclePotentialEnergyInfo(), SimTK::Stage::Velocity);
  }
 
@@ -291,7 +290,7 @@ double Muscle::getExcitation( const SimTK::State& s) const {
     and has a normalized (0 to 1) value */
 double Muscle::getActivation(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).activation;
+    return getFiberVelocityInfo(s).activation;
 }
 
 /* get the current working fiber length (m) for the muscle */
@@ -357,13 +356,13 @@ double Muscle::getMusclePotentialEnergy(const SimTK::State& s) const
 /* get the passive fiber (parallel elastic element) force multiplier */
 double Muscle::getPassiveForceMultiplier(const SimTK::State& s) const
 {
-    return getMuscleLengthInfo(s).fiberPassiveForceLengthMultiplier;
+    return getFiberVelocityInfo(s).fiberPassiveForceLengthMultiplier;
 }
 
 /* get the active fiber (contractile element) force multiplier due to current fiber length */
 double Muscle::getActiveForceLengthMultiplier(const SimTK::State& s) const
 {
-    return getMuscleLengthInfo(s).fiberActiveForceLengthMultiplier;
+    return getFiberVelocityInfo(s).fiberActiveForceLengthMultiplier;
 }
 
 /* get current fiber velocity (m/s) positive is lengthening */
@@ -405,52 +404,52 @@ double Muscle::getPennationAngularVelocity(const SimTK::State& s) const
 /* get the current fiber force (N)*/
 double Muscle::getFiberForce(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).fiberForce;
+    return getFiberVelocityInfo(s).fiberForce;
 }
 
 /* get the current fiber force (N) applied to the tendon */
 double Muscle::getFiberForceAlongTendon(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).fiberForceAlongTendon;
+    return getFiberVelocityInfo(s).fiberForceAlongTendon;
 }
 
 
 /* get the current active fiber force (N) due to activation*force_length*force_velocity relationships */
 double Muscle::getActiveFiberForce(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).activeFiberForce;
+    return getFiberVelocityInfo(s).activeFiberForce;
 }
 
 /* get the total force applied by all passive elements in the fiber (N) */
 double Muscle::getPassiveFiberForce(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).passiveFiberForce;
+    return getFiberVelocityInfo(s).passiveFiberForce;
 }
 
 /* get the current active fiber force (N) projected onto the tendon direction */
 double Muscle::getActiveFiberForceAlongTendon(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).activeFiberForce * getMuscleLengthInfo(s).cosPennationAngle;
+    return getFiberVelocityInfo(s).activeFiberForce * getMuscleLengthInfo(s).cosPennationAngle;
 }
 
 /* get the total force applied by all passive elements in the fiber (N)
    projected onto the tendon direction */
 double Muscle::getPassiveFiberForceAlongTendon(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).passiveFiberForce * getMuscleLengthInfo(s).cosPennationAngle;
+    return getFiberVelocityInfo(s).passiveFiberForce * getMuscleLengthInfo(s).cosPennationAngle;
 }
 
 /* get the current tendon force (N) applied to bones */
 double Muscle::getTendonForce(const SimTK::State& s) const
 {
-    return getMaxIsometricForce() * getMuscleDynamicsInfo(s).normTendonForce;
+    return getMaxIsometricForce() * getFiberVelocityInfo(s).normTendonForce;
 }
 
 /* get the current fiber stiffness (N/m) defined as the partial derivative
     of fiber force w.r.t. fiber length */
 double Muscle::getFiberStiffness(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).fiberStiffness;
+    return getFiberVelocityInfo(s).fiberStiffness;
 }
 
 /* get the current fiber stiffness (N/m) defined as the partial derivative
@@ -458,7 +457,7 @@ double Muscle::getFiberStiffness(const SimTK::State& s) const
     along the tendon*/
 double Muscle::getFiberStiffnessAlongTendon(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).fiberStiffnessAlongTendon;
+    return getFiberVelocityInfo(s).fiberStiffnessAlongTendon;
 }
 
 
@@ -466,38 +465,38 @@ double Muscle::getFiberStiffnessAlongTendon(const SimTK::State& s) const
     of tendon force w.r.t. tendon length */
 double Muscle::getTendonStiffness(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).tendonStiffness;
+    return getFiberVelocityInfo(s).tendonStiffness;
 }
 
 /* get the current muscle stiffness (N/m) defined as the partial derivative
     of muscle force w.r.t. muscle length */
 double Muscle::getMuscleStiffness(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).muscleStiffness;
+    return getFiberVelocityInfo(s).muscleStiffness;
 }
 
 /* get the current fiber power (W) */
 double Muscle::getFiberActivePower(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).fiberActivePower;
+    return getFiberVelocityInfo(s).fiberActivePower;
 }
 
 /* get the current fiber active power (W) */
 double Muscle::getFiberPassivePower(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).fiberPassivePower;
+    return getFiberVelocityInfo(s).fiberPassivePower;
 }
 
 /* get the current tendon power (W) */
 double Muscle::getTendonPower(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).tendonPower;
+    return getFiberVelocityInfo(s).tendonPower;
 }
 
 /* get the current muscle power (W) */
 double Muscle::getMusclePower(const SimTK::State& s) const
 {
-    return getMuscleDynamicsInfo(s).musclePower;
+    return getFiberVelocityInfo(s).musclePower;
 }
 
 
@@ -541,24 +540,6 @@ Muscle::FiberVelocityInfo& Muscle::
 updFiberVelocityInfo(const SimTK::State& s) const
 {
     return updCacheVariableValue(s, _velInfoCV);
-}
-
-const Muscle::MuscleDynamicsInfo& Muscle::
-getMuscleDynamicsInfo(const SimTK::State& s) const
-{
-    if (isCacheVariableValid(s, _dynamicsInfoCV)) {
-        return getCacheVariableValue(s, _dynamicsInfoCV);
-    }
-
-    MuscleDynamicsInfo& umdi = updCacheVariableValue(s, _dynamicsInfoCV);
-    calcMuscleDynamicsInfo(s, umdi);
-    markCacheVariableValid(s, _dynamicsInfoCV);
-    return umdi;
-}
-Muscle::MuscleDynamicsInfo& Muscle::
-updMuscleDynamicsInfo(const SimTK::State& s) const
-{
-    return updCacheVariableValue(s, _dynamicsInfoCV);
 }
 
 const Muscle::MusclePotentialEnergyInfo& Muscle::
@@ -612,14 +593,6 @@ void Muscle::calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi
         + "::calcFiberVelocityInfo() NOT IMPLEMENTED.");
 }
 
-/* calculate muscle's active and passive force-length, force-velocity,
-    tendon force, relationships and their related values */
-void Muscle::calcMuscleDynamicsInfo(const SimTK::State& s, MuscleDynamicsInfo& mdi) const
-{
-    throw Exception("ERROR- "+getConcreteClassName()
-        + "::calcMuscleDynamicsInfo() NOT IMPLEMENTED.");
-}
-
 /* calculate muscle's fiber and tendon potential energy */
 void Muscle::calcMusclePotentialEnergyInfo(const SimTK::State& s,
     MusclePotentialEnergyInfo& mpei) const
@@ -638,7 +611,7 @@ double Muscle::calcInextensibleTendonActiveFiberForce(SimTK::State& s,
     const MuscleLengthInfo& mli = getMuscleLengthInfo(s);
     const FiberVelocityInfo& fvi = getFiberVelocityInfo(s);
     return getMaxIsometricForce()*activation*
-        mli.fiberActiveForceLengthMultiplier*fvi.fiberForceVelocityMultiplier
+        fvi.fiberActiveForceLengthMultiplier*fvi.fiberForceVelocityMultiplier
         *mli.cosPennationAngle;
 }
 

--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -829,13 +829,7 @@ protected:
 
     void calcFiberVelocityInfoCache(
         const SimTK::State& s,
-        FiberVelocityInfoCache& fvi) const
-    {
-        MuscleLengthInfo& mli = fvi;
-        // Copy the length info fields.
-        mli = getMuscleLengthInfo(s);
-        calcFiberVelocityInfo(s, mli, fvi);
-    }
+        FiberVelocityInfoCache& fvi) const;
 
     const FiberVelocityInfoCache& getFiberVelocityInfo(const SimTK::State& s) const;
 

--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -715,8 +715,6 @@ protected:
         double fiberStiffness;          // force/length         N/m
         double tendonStiffness;         // force/length         N/m
 
-        SimTK::Vector userDefinedVelocityExtras;//NA                  NA
-
         FiberVelocityInfo(): 
             fiberVelocity(SimTK::NaN), 
             fiberPassiveForceLengthMultiplier(SimTK::NaN),
@@ -729,8 +727,8 @@ protected:
             passiveDampingFiberForce(SimTK::NaN),
             tendonForce(SimTK::NaN),
             fiberStiffness(SimTK::NaN),
-            tendonStiffness(SimTK::NaN),
-            userDefinedVelocityExtras(0, SimTK::NaN){};
+            tendonStiffness(SimTK::NaN)
+        {}
         friend std::ostream& operator<<(std::ostream& o, 
             const FiberVelocityInfo& fvi) {
             o << "Muscle::FiberVelocityInfo should not be serialized!"

--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -524,14 +524,6 @@ protected:
           // 
          //  
         //     
-
-    [6] This vector is left for the muscle modeler to populate with any
-        computationally expensive quantities that are computed in 
-        calcMuscleLengthInfo, and required for use in the user defined functions 
-        calcFiberVelocityInfo and calcMuscleDynamicsInfo. None of the parent 
-        classes make any assumptions about what is or isn't in this field 
-        - use as necessary.
-       
     */
     struct MuscleLengthInfo{             //DIMENSION         Units      
         double fiberLength;              //length            m  
@@ -546,8 +538,6 @@ protected:
         double cosPennationAngle;        //NA                NA         
         double sinPennationAngle;        //NA                NA         
 
-        SimTK::Vector userDefinedLengthExtras;//NA        NA
-
         MuscleLengthInfo(): 
             fiberLength(SimTK::NaN), 
             fiberLengthAlongTendon(SimTK::NaN),
@@ -557,8 +547,8 @@ protected:
             tendonStrain(SimTK::NaN), 
             pennationAngle(SimTK::NaN), 
             cosPennationAngle(SimTK::NaN),
-            sinPennationAngle(SimTK::NaN),
-            userDefinedLengthExtras(0, SimTK::NaN){}
+            sinPennationAngle(SimTK::NaN)
+        {}
         friend std::ostream& operator<<(std::ostream& o, 
             const MuscleLengthInfo& mli) {
             o << "Muscle::MuscleLengthInfo should not be serialized!" 

--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -570,69 +570,43 @@ protected:
         of the muscle path, and any forces the muscle experiences will not be 
         known.
 
-            NAME                     DIMENSION             UNITS
-             fiberVelocity             length/time           m/s
-             fiberVelocityAlongTendon  length/time           m/s       [1]
-             normFiberVelocity         (length/time)/Vmax    NA        [2]
-             
-             pennationAngularVelocity  angle/time            rad/s     [3]
-             
-             tendonVelocity            length/time           m/s       
-             normTendonVelocity        (length/time)/length  (m/s)/m   [4]
-             
-             fiberPassiveForceLengthMultiplier   force/force     N/N      [5]
-             fiberActiveForceLengthMultiplier    force/force     N/N      [6]
-             fiberForceVelocityMultiplier force/force          NA        [7]
+            NAME                               DIMENSION        UNITS
+             fiberVelocity                     length/time      m/s
+             tendonVelocity                    length/time      m/s
 
-             activation                  NA                   NA     [8]
+             fiberPassiveForceLengthMultiplier force/force      N/N     [1]
+             fiberActiveForceLengthMultiplier  force/force      N/N     [2]
+             fiberForceVelocityMultiplier      force/force      NA      [3]
 
-             fiberForce                  force                N
-             fiberForceAlongTendon       force                N      [9]
-             normFiberForce              force/force          N/N    [10]
-             activeFiberForce            force                N      [11]
-             passiveFiberForce           force                N      [12]
+             activation                        NA               NA      [4]
 
-             tendonForce                 force                N
-             normTendonForce             force/force          N/N    [13]
+             fiberForce                        force            N
+             activeFiberForce                  force            N       [5]
+             passiveElasticFiberForce          force            N       [6]
+             passiveDampingFiberForce          force            N       [7]
 
-             fiberStiffness              force/length         N/m    [14]
-             fiberStiffnessAlongTendon   force/length         N/m    [15]
-             tendonStiffness             force/length         N/m    [16]
-             muscleStiffness             force/length         N/m    [17]
+             tendonForce                       force            N
 
-             fiberActivePower            force*velocity       W (N*m/s)
-             fiberPassivePower           force*velocity       W (N*m/s)
-             tendonPower                 force*velocity       W (N*m/s)
-             musclePower                 force*velocity       W (N*m/s)
+             fiberStiffness                    force/length     N/m     [8]
+             tendonStiffness                   force/length     N/m     [9]
 
-             userDefinedVelocityExtras    NA                   NA      [18]
-        
-        [1] fiberVelocityAlongTendon is the first derivative of the symbolic
-            equation that defines the fiberLengthAlongTendon.
-
-        [2] normFiberVelocity is the fiberVelocity (in m/s) divided by  
+        [1] normFiberVelocity is the fiberVelocity (in m/s) divided by
             the optimal length of the fiber (in m) and by the maximum fiber
             velocity (in optimal-fiber-lengths/s). normFiberVelocity has
             units of 1/optimal-fiber-length.
 
-        [3] The sign of the angular velocity is defined using the right 
-            hand rule.
-
-        [4] normTendonVelocity is the tendonVelocity (the lengthening velocity 
-            of the tendon) divided by its resting length
-
-        [6] The fiberPassiveForceLengthMultiplier represents the elastic force the fiber
+        [2] The fiberPassiveForceLengthMultiplier represents the elastic force the fiber
             generates normalized w.r.t. the maximum isometric force of the fiber.
             Is typically specified by a passiveForceLengthCurve.
 
-        [7] The fiberActiveForceLengthMultiplier is the scaling of the maximum force a fiber
+        [3] The fiberActiveForceLengthMultiplier is the scaling of the maximum force a fiber
             can generate as a function of its length. This term usually follows a
             curve that is zero at a normalized fiber length of 0.5, is 1 at a
             normalized fiber length of 1, and then zero again at a normalized fiber
             length of 1.5. This curve is generally an interpolation of experimental
             data.
 
-        [5] The fiberForceVelocityMultiplier is the scaling factor that represents
+        [4] The fiberForceVelocityMultiplier is the scaling factor that represents
             how a muscle fiber's force generating capacity is modulated by the
             contraction (concentric or eccentric) velocity of the fiber.
             Generally this curve has a value of 1 at a fiber velocity of 0, 
@@ -641,59 +615,22 @@ protected:
             velocity. The force velocity curve, which computes this term,  
             is usually an interpolation of an experimental curve.
 
-        [6] This vector is left for the muscle modeler to populate with any
-            computationally expensive quantities that are computed in 
-            calcFiberVelocityInfo, and required for use in the user defined 
-            function calcMuscleDynamicsInfo. None of the parent classes make 
-            any assumptions about what is or isn't in this field
-            - use as necessary.
-
-        [6] This is a quantity that ranges between 0 and 1 that dictates how
+        [5] This is a quantity that ranges between 0 and 1 that dictates how
             on or activated a muscle is. This term may or may not have its own
             time dependent behavior depending on the muscle model.
 
-        [7] fiberForceAlongTendon is the fraction of the force that is developed
-            by the fiber that is transmitted to the tendon. This fraction 
-            depends on the pennation model that is used for the muscle model
-
-        [8] This is the force developed by the fiber scaled by the maximum 
-            isometric contraction force. Note that the maximum isometric force
-            is defined as the maximum isometric force a muscle fiber develops
-            at its optimal pennation angle, and along the line of the fiber.
-
-        [9] This is the portion of the fiber force that is created as a direct
+        [6] This is the portion of the fiber force that is created as a direct
             consequence of the value of 'activation'.
 
-        [10] This is the portion of the fiber force that is created by the 
+        [7] This is the portion of the fiber force that is created by the
             parallel elastic element within the fiber.
-    
-        [11] This is the tendonForce normalized by the maximum isometric 
-            contraction force
 
-        [12] fiberStiffness is defined as the partial derivative of fiber force
+        [8] fiberStiffness is defined as the partial derivative of fiber force
             with respect to fiber length
 
-        [13] fiberStiffnessAlongTendon is defined as the partial derivative of 
-            fiber force along the tendon with respect to small changes in
-            the fiber length along the tendon. This quantity is normally 
-            computed using the equations for fiberStiffness, and then using an 
-            application of the chain rule to yield fiberStiffnessAlongTendon.
-
-        [14] tendonStiffness is defined as the partial derivative of tendon
+        [9] tendonStiffness is defined as the partial derivative of tendon
             force with respect to tendon length
 
-        [15] muscleStiffness is defined as the partial derivative of muscle force
-            with respect to changes in muscle length. This quantity can usually
-            be computed by noting that the tendon and the fiber are in series,
-            with the fiber at a pennation angle. Thus
-
-            Kmuscle =   (Kfiber_along_tendon * Ktendon)
-                       /(Kfiber_along_tendon + Ktendon) 
-
-        [16] This vector is left for the muscle modeler to populate with any
-             computationally expensive quantities that might be of interest 
-             after dynamics calculations are completed but maybe of use
-             in computing muscle derivatives or reporting values of interest.
 
     */
     struct FiberVelocityInfo {              //DIMENSION             UNITS
@@ -740,12 +677,21 @@ protected:
     struct FiberVelocityInfoCache : MuscleLengthInfo,
                                     FiberVelocityInfo
     {
+
+        /**
+            Computes the pennation angular velocity, with the sign defined
+            using the right hand rule.
+        */
         double calcPennationAngularVelocity() const
         {
             return -(fiberVelocity / fiberLength) * sinPennationAngle /
                    cosPennationAngle;
         }
 
+        /**
+            fiberVelocityAlongTendon is the first derivative of the symbolic
+            equation that defines the fiberLengthAlongTendon.
+         */
         double calcFiberVelocityAlongTendon() const
         {
             return fiberVelocity * cosPennationAngle -
@@ -762,6 +708,13 @@ protected:
             return passiveElasticFiberForce + passiveDampingFiberForce;
         }
 
+
+        /**
+            fiberForceAlongTendon is the fraction of the force that is
+            developed by the fiber that is transmitted to the tendon. This
+            fraction depends on the pennation model that is used for the muscle
+            model
+        */
         double calcFiberForceAlongTendon() const
         {
             return fiberForce * cosPennationAngle;
@@ -782,6 +735,11 @@ protected:
             return passiveDampingFiberForce * cosPennationAngle;
         }
 
+        /**
+            FiberStiffnessAlongTendon is defined as the partial derivative of
+            fiber force along the tendon with respect to small changes in the
+            fiber length along the tendon.
+        */
         double calcFiberStiffnessAlongTendon() const
         {
             double DcosPhi_Dlce =
@@ -792,6 +750,15 @@ protected:
             return DfmAT_Dlce * Dlce_DlceAT;
         }
 
+        /**
+            Musclestiffness is defined as the partial derivative of muscle
+            force with respect to changes in muscle length. Noting that the
+            tendon and the fiber are in series, with the fiber at a pennation
+            angle, we have:
+
+            Kmuscle = (Kfiber_along_tendon * Ktendon)
+                        / (Kfiber_along_tendon + Ktendon)
+        */
         double calcMuscleStiffness(bool ignoreTendonCompliance) const
         {
             double fiber_stiffness_along_tendon =

--- a/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
+++ b/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
@@ -271,20 +271,20 @@ public:
         // for force F, then applying the modifications described in [1].
         // Negative fiber velocity corresponds to concentric contraction.
         double ArelStar = pow(fvi.activation,-0.3) * get_Arel();
-        if (getFiberVelocity(s) <= 0) {
-            double v  = max(getFiberVelocity(s),
+        if (fvi.fiberVelocity <= 0) {
+            double v  = max(fvi.fiberVelocity,
                         -getMaxContractionVelocity() * getOptimalFiberLength());
             double t1 = get_Brel() * getOptimalFiberLength();
-            fvi.fiberForce = (t1*getActiveForceLengthMultiplier(s) + ArelStar*v)
+            fvi.fiberForce = (t1*fvi.fiberActiveForceLengthMultiplier + ArelStar*v)
                              / (t1 - v);
         } else {
             double c2 = -get_FmaxEccentric() / fvi.activation;
             double c3 = (get_FmaxEccentric()-1) * get_Brel() / (fvi.activation *
-                            2 * (getActiveForceLengthMultiplier(s) + ArelStar));
+                            2 * (fvi.fiberActiveForceLengthMultiplier + ArelStar));
             double c1 = (get_FmaxEccentric()-1) * c3 / fvi.activation;
             fvi.fiberForce = -(getOptimalFiberLength() * (c1 + c2*c3)
-                               + c2*getFiberVelocity(s)) /
-                             (getFiberVelocity(s) + c3*getOptimalFiberLength());
+                               + c2*fvi.fiberVelocity) /
+                             (fvi.fiberVelocity + c3*getOptimalFiberLength());
         }
         fvi.fiberForce *= getMaxIsometricForce() * fvi.activation;
 

--- a/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
+++ b/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
@@ -232,22 +232,17 @@ public:
     }
 
     // Calculate velocity-level variables.
-    void calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi)
+    void calcFiberVelocityInfo(
+            const SimTK::State& s,
+            const MuscleLengthInfo& mli,
+            FiberVelocityInfo& fvi)
         const override
     {
         fvi.fiberVelocity = getStateVariableValue(s, stateName_fiberVelocity);
-        fvi.fiberVelocityAlongTendon = fvi.fiberVelocity;
-        fvi.normFiberVelocity        = fvi.fiberVelocity /
-                        (getMaxContractionVelocity() * getOptimalFiberLength());
-
-        fvi.pennationAngularVelocity     = 0;
-        fvi.tendonVelocity               = 0;
-        fvi.normTendonVelocity           = 0;
 
         // The fiberActiveForceLengthMultiplier (referred to as 'Fisom' in [3])
         // is the proportion of maxIsometricForce that would be delivered
         // isometrically at maximal activation. Fisom=1 if Lce=Lceopt.
-        const MuscleLengthInfo& mli = getMuscleLengthInfo(s);
         if (mli.fiberLength < (1 - get_width()) * getOptimalFiberLength() ||
             mli.fiberLength > (1 + get_width()) * getOptimalFiberLength())
             fvi.fiberActiveForceLengthMultiplier = 0;
@@ -288,20 +283,10 @@ public:
         }
         fvi.fiberForce *= getMaxIsometricForce() * fvi.activation;
 
-        fvi.fiberForceAlongTendon = fvi.fiberForce;
-        fvi.normFiberForce        = fvi.fiberForce / getMaxIsometricForce();
         fvi.activeFiberForce      = fvi.fiberForce;
-        fvi.passiveFiberForce     = 0;
         fvi.tendonForce           = fvi.fiberForce;
-        fvi.normTendonForce       = fvi.normFiberForce;
         fvi.fiberStiffness        = 0;
-        fvi.fiberStiffnessAlongTendon = 0;
         fvi.tendonStiffness       = 0;
-        fvi.muscleStiffness       = 0;
-        fvi.fiberActivePower      = 0;
-        fvi.fiberPassivePower     = 0;
-        fvi.tendonPower           = 0;
-        fvi.musclePower           = 0;
     }
 
 private:


### PR DESCRIPTION
This PR combines `Muscle::FiberVelocityInfo` and `Muscle::MuscleDynamicsInfo` into a single cached variable, and removes member fields that are cheap to compute.

Considering that fetching memory is slower than multiplying a few numbers, the following fields are cheap to compute, and are removed:

- `FiberVelocityInfo::fiberVelocityAlongTendon`,
- `FiberVelocityInfo::normFiberVelocity`,
- `FiberVelocityInfo::pennationAngularVelocity`,
- `FiberVelocityInfo::normTendonVelocity`,
- `MuscleDynamicsInfo::fiberForceAlongTendon`,
- `MuscleDynamicsInfo::normFiberForce`,
- `MuscleDynamicsInfo::normTendonForce`,
- `MuscleDynamicsInfo::fiberStiffnessAlongTendon`,
- `MuscleDynamicsInfo::muscleStiffness`,
- `MuscleDynamicsInfo::tendonPower`,
- `MuscleDynamicsInfo::musclePower`,

This leaves two fields in `FiberVelocityInfo`.
When computing the fiber velocity, with the exeption of `Millard2012AccelerationMuscle`, all muscles need to compute the forces as well. The forces can thus be seen as a byproduct of computing the velocities,
Furthermore, the `FiberVelocityInfo` and `MuscleDynamicsInfo` cached variables are invalidated at the same stage (`Stage::Velocity`).
Finally, it turns out that distributing the `Muscle` information over 3 cached variables is slower than over 2.

Since computing the forces is actually part of computing the muscle velocities, I argue for combining `MuscleDynamicsInfo` with `FiberVelocityInfo`.

### Performance
Measuring the wall clock time for several simulations, shows around ~10% performance benefit:

| | main | this PR |
|---|---|---|
| CMC Running Model | 26.0 [secs] | 21.4 [secs]  (-22%)|
| Rajagopal forward integration | 6.5 [secs] | 5.9 [secs] (-10%) |

### Brief summary of changes

- Moved all fields from `MuscleDynamicsInfo` to `FiberVelocityInfo`,
- Removed `Muscle::calcMuscleDynamicsInfo()`, `Muscle::getMuscleDynamicsInfo` and the cached variable.
- Added cached variable to `Millard2012AccelerationMuscle` for caching the muscle-specific curve values.
- Added cached variable `FiberVelocityInfoCache` containing the `MuscleLengthInfo` and `FiberVelocityInfo` in a single struct
- Moved `fiberForceLengthMultiplier` and `fiberActiveForceLengthMultiplier` from `MuscleLengthInfo` to `FiberVelocityInfo` (since they are used to compute forces/velocities and not lengths).
- Added `calc` methods on `FiberVelocityInfoCache` variable for the removed fields mentioned above.

Some notes:
- I think a more fitting name for the combined cached variable would be `MuscleForceInfo`, but adding that to this PR will create a very large diff, so that would be a follow up PR.
- TODO: Thelen output changed, still debugging.
- TODO: DeGrooteMuscle unit tests are failing on small numerical differences (<1e-13).

### Testing I've completed

- [x] Rajagopal simulations showed no change in output.
- [ ] Thelen simulation showing no change in output.
- [ ] Unit tests passing

### Looking for feedback on

@aseth1 would be great if you have time to take a look at `Muscle.h`. I moved the curve computations from `MuscleLengthInfo` to `FiberVelocityInfo` because they appeared a byproduct of computing the fiber force. But I might have misunderstood the invalidating behavior of CMC.
@adamkewley I left the `calc` methods in `Muscle.h` in the header e.g. `Muscle.h::685`

### CHANGELOG.md (choose one)

- no need to update because...
- updated.
