### PR TITLE
Combines calculating muscle curve value and derivative

### DIFF
--- a/OpenSim/Actuators/ActiveForceLengthCurve.cpp
+++ b/OpenSim/Actuators/ActiveForceLengthCurve.cpp
@@ -158,6 +158,15 @@ double ActiveForceLengthCurve::calcValue(double normFiberLength) const
     return m_curve.calcValue(normFiberLength);
 }
 
+SmoothSegmentedFunction::ValueAndDerivative ActiveForceLengthCurve::
+    calcValueAndDerivative(double normFiberLength) const
+{
+    SimTK_ASSERT(
+        isObjectUpToDateWithProperties(),
+        "ActiveForceLengthCurve: Curve is not up-to-date with its properties");
+    return m_curve.calcValueAndFirstDerivative(normFiberLength);
+}
+
 double ActiveForceLengthCurve::calcDerivative(double normFiberLength,
                                               int order) const
 {

--- a/OpenSim/Actuators/ActiveForceLengthCurve.h
+++ b/OpenSim/Actuators/ActiveForceLengthCurve.h
@@ -209,6 +209,11 @@ public:
     'normFiberLength'. */
     double calcValue(double normFiberLength) const;
 
+    /** Evaluates the active-force-length curve value and derivative at a
+     * normalized fiber length of 'normFiberLength'. */
+    SmoothSegmentedFunction::ValueAndDerivative calcValueAndDerivative(
+        double normFiberLength) const;
+
 
     /** Calculates the derivative of the active-force-length multiplier with
     respect to the normalized fiber length.

--- a/OpenSim/Actuators/FiberForceLengthCurve.cpp
+++ b/OpenSim/Actuators/FiberForceLengthCurve.cpp
@@ -219,6 +219,15 @@ double FiberForceLengthCurve::calcValue(double normFiberLength) const
     return m_curve.calcValue(normFiberLength);
 }
 
+SmoothSegmentedFunction::ValueAndDerivative FiberForceLengthCurve::
+    calcValueAndDerivative(double normFiberLength) const
+{
+    SimTK_ASSERT(
+        isObjectUpToDateWithProperties(),
+        "FiberForceLengthCurve: Curve is not up-to-date with its properties");
+    return m_curve.calcValueAndFirstDerivative(normFiberLength);
+}
+
 double FiberForceLengthCurve::calcDerivative(double normFiberLength,
                                              int order) const
 {

--- a/OpenSim/Actuators/FiberForceLengthCurve.h
+++ b/OpenSim/Actuators/FiberForceLengthCurve.h
@@ -279,6 +279,11 @@ public:
     'normFiberLength'. */
     double calcValue(double normFiberLength) const;
 
+    /** Evaluates the fiber-force-length curve value and derivative at a
+    normalized fiber length of 'normFiberLength'. */
+    SmoothSegmentedFunction::ValueAndDerivative calcValueAndDerivative(
+        double normFiberLength) const;
+
     /** Calculates the derivative of the fiber-force-length multiplier with
     respect to the normalized fiber length.
     @param normFiberLength

--- a/OpenSim/Actuators/ForceVelocityCurve.cpp
+++ b/OpenSim/Actuators/ForceVelocityCurve.cpp
@@ -176,6 +176,15 @@ double ForceVelocityCurve::calcValue(double normFiberVelocity) const
     return m_curve.calcValue(normFiberVelocity);
 }
 
+SmoothSegmentedFunction::ValueAndDerivative ForceVelocityCurve::
+    calcValueAndDerivative(double normFiberVelocity) const
+{
+    SimTK_ASSERT(
+        isObjectUpToDateWithProperties(),
+        "ForceVelocityCurve: Curve is not up-to-date with its properties");
+    return m_curve.calcValueAndFirstDerivative(normFiberVelocity);
+}
+
 double ForceVelocityCurve::calcDerivative(double normFiberVelocity,
                                           int order) const
 {

--- a/OpenSim/Actuators/ForceVelocityCurve.h
+++ b/OpenSim/Actuators/ForceVelocityCurve.h
@@ -305,6 +305,11 @@ public:
     'normFiberVelocity'. */
     double calcValue(double normFiberVelocity) const;
 
+    /** Evaluates the force-velocity curve value and derivative at a normalized
+    fiber velocity of 'normFiberVelocity'. */
+    SmoothSegmentedFunction::ValueAndDerivative calcValueAndDerivative(
+        double normFiberVelocity) const;
+
     /** Calculates the derivative of the force-velocity multiplier with respect
     to the normalized fiber velocity.
     @param normFiberVelocity

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -225,7 +225,7 @@ DampedFiberVelocityCalculationResult calcDampedNormFiberVelocity(
     @param fiso the maximum isometric force the fiber can generate
     @param a activation
     @param fv the fiber force-velocity multiplier
-    @param fpe_dlceN the fiber force-length multiplier derivative
+    @param dfpe_dlceN the fiber force-length multiplier derivative
     @param dfal_dlceN the fiber active-force-length multiplier derivative
     @param optFibLen the optimal fiber length
 */
@@ -1138,13 +1138,9 @@ calcMuscleDynamicsInfo(const SimTK::State& s, MuscleDynamicsInfo& mdi) const
             mvi.userDefinedVelocityExtras[MVIIsFiberStateClamped];
 
         // Get the properties of this muscle.
-        double tendonSlackLen = getTendonSlackLength();
         double optFiberLen    = getOptimalFiberLength();
         double fiso           = getMaxIsometricForce();
         double beta           = getFiberDamping();
-
-        //double penHeight      = penMdl.getParallelogramHeight();
-        const TendonForceLengthCurve& fseCurve = get_TendonForceLengthCurve();
 
         // Compute dynamic quantities.
         double a = SimTK::NaN;

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
@@ -586,23 +586,6 @@ private:
                           double fpe,
                           double dlceN) const;
 
-    /*  @param fiso the maximum isometric force the fiber can generate
-        @param a activation
-        @param fal the fiber active-force-length multiplier
-        @param fv the fiber force-velocity multiplier
-        @param fpe the fiber force-length multiplier
-        @param sinphi the sine of the pennation angle
-        @param cosphi the cosine of the pennation angle
-        @param lce the fiber length
-        @param lceN the normalized fiber length
-        @param optFibLen the optimal fiber length
-        @returns the stiffness of the fiber in the direction of the fiber */
-    double calcFiberStiffness(double fiso,
-                              double a,
-                              double fv,
-                              double lceN,
-                              double optFibLen) const;
-
     /*  @param fiberForce the force, in Newtons, developed by the fiber
         @param fiberStiffness the stiffness, in N/m, of the fiber
         @param lce the fiber length

--- a/OpenSim/Actuators/TendonForceLengthCurve.cpp
+++ b/OpenSim/Actuators/TendonForceLengthCurve.cpp
@@ -223,6 +223,15 @@ double TendonForceLengthCurve::calcValue(double aNormLength) const
     return m_curve.calcValue(aNormLength);
 }
 
+SmoothSegmentedFunction::ValueAndDerivative TendonForceLengthCurve::
+    calcValueAndDerivative(double aNormLength) const
+{
+    SimTK_ASSERT(
+        isObjectUpToDateWithProperties(),
+        "TendonForceLengthCurve: Tendon is not up-to-date with its properties");
+    return m_curve.calcValueAndFirstDerivative(aNormLength);
+}
+
 double TendonForceLengthCurve::calcDerivative(double aNormLength,
                                               int order) const
 {

--- a/OpenSim/Actuators/TendonForceLengthCurve.h
+++ b/OpenSim/Actuators/TendonForceLengthCurve.h
@@ -263,6 +263,11 @@ public:
     'aNormLength'. */
     double calcValue(double aNormLength) const;
 
+    /** Evaluates the tendon-force-length curve value and derivative at a
+    normalized tendon length of 'aNormLength'. */
+    SmoothSegmentedFunction::ValueAndDerivative calcValueAndDerivative(
+        double aNormLength) const;
+
     /** Calculates the derivative of the tendon-force-length multiplier with
     respect to the normalized tendon length.
     @param aNormLength

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -183,7 +183,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    f31933bcd056a62cc7b81679368dc437bde12d3e
+              GIT_TAG    24b5fa4abcc87d8ff0b5f889deab4ea3e42b6560
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -183,7 +183,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    24b5fa4abcc87d8ff0b5f889deab4ea3e42b6560
+              GIT_TAG    930ae0feff0adb5aec184af62d14f9d138cacd48
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})


### PR DESCRIPTION
This PR replaces separate calls to `calcValue` and `calcDerivative` on the muscle curves in `Millard2012EquilibriumMuscle` by `calcValueAndDerivative`, which is more efficient.

The `MuscleLengthInfo::userDefinedLengthExtras` and  `FiberVelocityInfo::userDefinedVelocityExtras` buffers are used to store the derivatives of the curves until needed.

Measuring the wallclock time of Rajagopal forward integration, and CMC running-model (using Millard muscles) shows around 10% perf benefit:

| | main | with this PR |
|---|---|---|
|CMC_Run_Mill(d=0.1)| 25.777 | 22.931 -12.4% |
|RajaContact(d=0.1)| 6.4 | 5.8 ( -9.8% ) |

### Brief summary of changes

There are 4 relevant muscle curves in `Millard2012EquilibriumMuscle` which are calling `calcValue` and `calcDerivative`, which is combined to `calcValueAndDerivative` by this PR:

- Added `calcValueAndDerivative` method to:
    - `ActiveForceLengthCurve.h`
    - `TendonForceLengthCurve.h`
    - `FiberForceLengthCurve.h`
    - `TendonForceLengthCurve.h`

- Regarding the `ActiveForceLengthCurve` and `TendonForceLengthCurve`:
    - moved computing curve derivative to `calcMuscleLengthInfo`, and store result in `MuscleLengthInfo::userDefinedLengthExtras`
    - moved `Millard2012EquilibriumMuscle::calcFiberStiffness` to anonymous namespace (this was using the derivative values)

- Regarding the `ForceVelocityCurve`:
    - use `calcValueAndDerivative` during `calcDampedNormFiberVelocity()` instead of `calcValue` followed by `calcDerivative`.
    - return last evaluation of `fiberForceVelocityCurve` from `calcDampedNormFiberVelocity()`

- Regarding the `TendonForceLengthCurve`:
    - Compute fiberstiffness and tendonforcelength multiplier during `calcFiberVelocityInfo()` and store in `FiberVelocityInfo::userDefinedVelocityExtras`

### Testing I've completed

Unit tests are passing, and Rajagopal forward simulation as well as CMC on running-model gives no change in results.

### CHANGELOG.md

- no need to update because too minor change.